### PR TITLE
Fixes issue #24: Updating GET Snippet to use Java 11 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,9 +298,13 @@ Update the sample application with the snippet and add a test for it. After prov
 ### HTTP GET
 
 ```java
-    public static int httpGet(URL address) throws IOException {
-        HttpURLConnection con = (HttpURLConnection) address.openConnection();
-        return con.getResponseCode();
+    public static int httpGet(String address) throws IOException, InterruptedException {
+        var request = HttpRequest.newBuilder()
+                           .uri(URI.create(address))
+                           .GET()
+                           .build();
+        var response = HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+        return response.statusCode();
     }
 ```
 

--- a/src/main/java/Library.java
+++ b/src/main/java/Library.java
@@ -312,13 +312,17 @@ public class Library {
 
     /**
      * Performs HTTP GET request
-     * @param address the URL of the connection
+     * @param address the URL of the connection in String format, like "http://www.google.com"
      * @return HTTP status code
-     * @throws IOException
+     * @throws IOException, InterruptedException
      */
-    public static int httpGet(URL address) throws IOException {
-        HttpURLConnection con = (HttpURLConnection) address.openConnection();
-        return con.getResponseCode();
+    public static int httpGet(String address) throws IOException, InterruptedException {
+        var request = HttpRequest.newBuilder()
+                           .uri(URI.create(address))
+                           .GET()
+                           .build();
+        var response = HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+        return response.statusCode();
     }
     
     /**

--- a/src/test/java/LibraryTest.java
+++ b/src/test/java/LibraryTest.java
@@ -27,7 +27,6 @@ import java.awt.*;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.ParseException;
@@ -279,8 +278,8 @@ public class LibraryTest {
      * Tests for {@link Library#httpGet(URL)}
      */
     @Test
-    public void testHttpGet() throws IOException {
-        int responseCode = Library.httpGet(new URL("http://www.google.com"));
+    public void testHttpGet() throws IOException, InterruptedException {
+        var responseCode = Library.httpGet("http://www.google.com");
         assertEquals(200, responseCode);
     }
     


### PR DESCRIPTION
This fixes #24 

The only real change is the fact the function parameter now accepts the URL in String format and not as the **URL** as created by the ```java.net.URL``` package, since the **HttpClient** Library accepts a *URI*, not *URL*. Also, I believe that it's easier for the end user to pass a String as address rather than URL-encoding it 😄 

Rest everything is related to *refractoring*. Do tell me if something else needs to be changed