### PR TITLE
Added get fields name method

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ For new snippets the general steps are
 
 ### Class
 * [Get methods name](#Get-methods-name)
+* [Get fields name](#Get-fields-name)
 
 ## Algorithm
 
@@ -443,6 +444,16 @@ public boolean isAnagram(String s1, String s2) {
         }
         return list;
     }
+```
+
+### Get fields name
+
+```java
+  public static List<String> getAllFieldNames(final Class<?> cls) {
+    return Arrays.stream(cls.getFields())
+            .map(Field::getName)
+            .collect(Collectors.toList());
+  }
 ```
 
 [⬆ back to top](#table-of-contents)

--- a/src/main/java/Library.java
+++ b/src/main/java/Library.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
@@ -52,6 +53,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import javax.imageio.ImageIO;
@@ -445,5 +447,16 @@ public class Library {
       list.add(method.getName());
     }
     return list;
+  }
+
+  /**
+   * Print all declared public field names of the class or the interface the class extends
+   * @param cls Tested class
+   * @return list of name of public fields
+   */
+  public static List<String> getAllFieldNames(final Class<?> cls) {
+    return Arrays.stream(cls.getFields())
+            .map(Field::getName)
+            .collect(Collectors.toList());
   }
 }

--- a/src/test/java/LibraryTest.java
+++ b/src/test/java/LibraryTest.java
@@ -393,7 +393,13 @@ public class LibraryTest {
    */
   @Test
   public void testGetAllFieldNames() {
-    var list = Library.getAllFieldNames(Library.class);
-    assertEquals(list.size(), 0);
+    class TestClass {
+      public int fieldOne;
+      public int fieldTwo;
+    }
+    var list = Library.getAllFieldNames(TestClass.class);
+    assertEquals(list.size(), 2);
+    assert (list.contains("fieldOne"));
+    assert (list.contains("fieldTwo"));
   }
 }

--- a/src/test/java/LibraryTest.java
+++ b/src/test/java/LibraryTest.java
@@ -371,4 +371,13 @@ public class LibraryTest {
     assertNotEquals("multiArrayConcat", list.get(0));
     assertNotEquals("arrayConcat", list.get(1));
   }
+
+  /**
+   * Tests for {@link Library#getAllFieldNames(Class)}.
+   */
+  @Test
+  public void testGetAllFieldNames() {
+    var list = Library.getAllFieldNames(Library.class);
+    assertEquals(list.size(), 0);
+  }
 }


### PR DESCRIPTION
Adding `getAllFieldsName` snippet

It lists all the public fields of a class or an interface which the class extends 