### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 30 Seconds of Java
 
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2FpH-7%2FSimple-Java-Calculator&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
+
 ![Java CI with Gradle](https://github.com/iluwatar/30-seconds-of-java/workflows/Java%20CI%20with%20Gradle/badge.svg)
 [![Join the chat at https://gitter.im/iluwatar/30-seconds-of-java](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/iluwatar/30-seconds-of-java?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. This can be simply added in the website also.

This just changes the `README.md` file.

The effect is just like this:
 
![Screenshot (1629)](https://user-images.githubusercontent.com/47092464/98441532-f576fb00-2139-11eb-9da6-7f52d9841d04.png)
