### PR TITLE
Added ELO Rating Snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,23 @@ public static int calculateLuhnChecksum(long num) {
   
 ```
 
+### Elo Ratng
+
+```java
+
+final static int BASE = 400; 
+final static int RATING_ADJUSTMENT_FACTOR = 32;
+
+public static double calculateMatchRating(double firstPlayerRating, double secondPlayerRating, double result) {
+    double ratingDiff = ((secondPlayerRating - firstPlayerRating) * 1.0) / BASE;
+    double logisticDiff = Math.pow(10, ratingDiff);
+    double firstPlayerExpectedScore = 1.0 / (1 + logisticDiff);
+    double firstPlayerActualScore = result;
+    double newRating = firstPlayerRating + RATING_ADJUSTMENT_FACTOR * (firstPlayerActualScore - firstPlayerExpectedScore);
+    return newRating;
+  }
+```
+
 ## Media
 
 ### Capture screen

--- a/src/main/java/math/EloRatingSnippet.java
+++ b/src/main/java/math/EloRatingSnippet.java
@@ -29,23 +29,26 @@ package math;
  */
 public class EloRatingSnippet {
 
-  final static int BASE = 400; //Two types are popular in Fide - 400 and 480. We will choose 400 here
-  final static int RATING_ADJUSTMENT_FACTOR = 32; //32 is the standard for Beginner Games
+  static final int BASE = 400; //Two types are popular - 400 and 480. We will choose 400 here
+  static final int RATING_ADJUSTMENT_FACTOR = 32; //32 is the standard for Beginner Games
 
   /**
-   * Elo Rating Snippet to calculate result after a single match
+   * Elo Rating Snippet to calculate result after a single match.
    *
-   * @param firstPlayerRating Rating of the first player
-   * @param secondPlayerRating Rating of the second player
-   * @param result Result of the match, always considered with respect to the first player. 1 indicates a win, 0.5 indicates a draw and 0 indicates a loss
-   * @return Returns the new rating of the first player
+   * @param firstPlayerRating Rating of the first player.
+   * @param secondPlayerRating Rating of the second player.
+   * @param result Result of the match, always considered with respect to the first player.
+   *               1 indicates a win, 0.5 indicates a draw and 0 indicates a loss.
+   * @return Returns the new rating of the first player.
    */
-  public static double calculateMatchRating(double firstPlayerRating, double secondPlayerRating, double result) {
+  public static double calculateMatchRating(double firstPlayerRating, double secondPlayerRating,
+    double result) {
     double ratingDiff = ((secondPlayerRating - firstPlayerRating) * 1.0) / BASE;
     double logisticDiff = Math.pow(10, ratingDiff);
     double firstPlayerExpectedScore = 1.0 / (1 + logisticDiff);
     double firstPlayerActualScore = result;
-    double newRating = firstPlayerRating + RATING_ADJUSTMENT_FACTOR * (firstPlayerActualScore - firstPlayerExpectedScore);
+    double newRating = firstPlayerRating + RATING_ADJUSTMENT_FACTOR * (firstPlayerActualScore -
+                       firstPlayerExpectedScore);
     return newRating;
   }
 }

--- a/src/main/java/math/EloRatingSnippet.java
+++ b/src/main/java/math/EloRatingSnippet.java
@@ -42,13 +42,13 @@ public class EloRatingSnippet {
    * @return Returns the new rating of the first player.
    */
   public static double calculateMatchRating(double firstPlayerRating, double secondPlayerRating,
-    double result) {
+      double result) {
     double ratingDiff = ((secondPlayerRating - firstPlayerRating) * 1.0) / BASE;
     double logisticDiff = Math.pow(10, ratingDiff);
     double firstPlayerExpectedScore = 1.0 / (1 + logisticDiff);
     double firstPlayerActualScore = result;
-    double newRating = firstPlayerRating + RATING_ADJUSTMENT_FACTOR * (firstPlayerActualScore -
-                       firstPlayerExpectedScore);
+    double newRating = firstPlayerRating + RATING_ADJUSTMENT_FACTOR * (firstPlayerActualScore 
+                       - firstPlayerExpectedScore);
     return newRating;
   }
 }

--- a/src/main/java/math/EloRatingSnippet.java
+++ b/src/main/java/math/EloRatingSnippet.java
@@ -1,0 +1,51 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017-2023 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package math;
+
+/**
+ * FactorialSnippet.
+ */
+public class EloRatingSnippet {
+
+  final static int BASE = 400; //Two types are popular in Fide - 400 and 480. We will choose 400 here
+  final static int RATING_ADJUSTMENT_FACTOR = 32; //32 is the standard for Beginner Games
+
+  /**
+   * Elo Rating Snippet to calculate result after a single match
+   *
+   * @param firstPlayerRating Rating of the first player
+   * @param secondPlayerRating Rating of the second player
+   * @param result Result of the match, always considered with respect to the first player. 1 indicates a win, 0.5 indicates a draw and 0 indicates a loss
+   * @return Returns the new rating of the first player
+   */
+  public static double calculateMatchRating(double firstPlayerRating, double secondPlayerRating, double result) {
+    double ratingDiff = ((secondPlayerRating - firstPlayerRating) * 1.0) / BASE;
+    double logisticDiff = Math.pow(10, ratingDiff);
+    double firstPlayerExpectedScore = 1.0 / (1 + logisticDiff);
+    double firstPlayerActualScore = result;
+    double newRating = firstPlayerRating + RATING_ADJUSTMENT_FACTOR * (firstPlayerActualScore - firstPlayerExpectedScore);
+    return newRating;
+  }
+}

--- a/src/test/java/math/EloRatingSnippetTest.java
+++ b/src/test/java/math/EloRatingSnippetTest.java
@@ -57,7 +57,6 @@ class EloRatingSnippetTest {
 
     //Simulate a tournament, using data from wikipedia
     double initialRating = 1613.0;
-    double expectedFinalRating = 1601.0; 
     double newRating = EloRatingSnippet.calculateMatchRating(initialRating, 1609.0, 0); // Loss
 
     //Match 2
@@ -72,6 +71,7 @@ class EloRatingSnippetTest {
     //Match 5
     newRating = EloRatingSnippet.calculateMatchRating(newRating, 1720.0, 0.0); //Loss
 
+    double expectedFinalRating = 1601.0; 
     assertEquals(expectedFinalRating, initialRating, DELTA);
   }
 }

--- a/src/test/java/math/EloRatingSnippetTest.java
+++ b/src/test/java/math/EloRatingSnippetTest.java
@@ -34,15 +34,13 @@ import org.junit.jupiter.api.Test;
  */
 class EloRatingSnippetTest {
 
-   final double DELTA = 0.01; // Add tolerance for floating point calculations
+  static final double DELTA = 0.01; // Add tolerance for floating point calculations
 
   /**
    * Tests for {@link #calculateMatchRating(double, double, double)}.
    */
   @Test
   void testSingleMatchRatings() {
-
-    
 
     //No rating change for draw between players of equal strength
     assertEquals(1500.0, EloRatingSnippet.calculateMatchRating(1500, 1500, 0.5), DELTA);
@@ -57,24 +55,23 @@ class EloRatingSnippetTest {
   @Test
   void testTournamentRatings() {
 
-      //Simulate a tournament, using data from wikipedia
-      double initialRating = 1613.0;
-      double expectedFinalRating = 1601.0; 
-      double newRating = EloRatingSnippet.calculateMatchRating(initialRating, 1609.0, 0); // Loss
+    //Simulate a tournament, using data from wikipedia
+    double initialRating = 1613.0;
+    double expectedFinalRating = 1601.0; 
+    double newRating = EloRatingSnippet.calculateMatchRating(initialRating, 1609.0, 0); // Loss
 
-      //Match 2
-      newRating = EloRatingSnippet.calculateMatchRating(newRating, 1477.0, 0.5); //Draw
+    //Match 2
+    newRating = EloRatingSnippet.calculateMatchRating(newRating, 1477.0, 0.5); //Draw
 
-      //Match 3
-      newRating = EloRatingSnippet.calculateMatchRating(newRating, 1388.0, 1.0); //Win
+    //Match 3
+    newRating = EloRatingSnippet.calculateMatchRating(newRating, 1388.0, 1.0); //Win
 
-      //Match 4
-      newRating = EloRatingSnippet.calculateMatchRating(newRating, 1586.0, 1.0); //Win
+    //Match 4
+    newRating = EloRatingSnippet.calculateMatchRating(newRating, 1586.0, 1.0); //Win
 
-      //Match 5
-      newRating = EloRatingSnippet.calculateMatchRating(newRating, 1720.0, 0.0); //Loss
+    //Match 5
+    newRating = EloRatingSnippet.calculateMatchRating(newRating, 1720.0, 0.0); //Loss
 
-      assertEquals(expectedFinalRating, initialRating, DELTA);
-
+    assertEquals(expectedFinalRating, initialRating, DELTA);
   }
 }

--- a/src/test/java/math/EloRatingSnippetTest.java
+++ b/src/test/java/math/EloRatingSnippetTest.java
@@ -50,28 +50,9 @@ class EloRatingSnippetTest {
 
     //For a loss against a very very low leveled player, we should lose max points
     assertEquals(2968.0, EloRatingSnippet.calculateMatchRating(3000, 1500, 0.0), DELTA);
-  }
 
-  @Test
-  void testTournamentRatings() {
-
-    //Simulate a tournament, using data from wikipedia
-    double initialRating = 1613.0;
-    double newRating = EloRatingSnippet.calculateMatchRating(initialRating, 1609.0, 0); // Loss
-
-    //Match 2
-    newRating = EloRatingSnippet.calculateMatchRating(newRating, 1477.0, 0.5); //Draw
-
-    //Match 3
-    newRating = EloRatingSnippet.calculateMatchRating(newRating, 1388.0, 1.0); //Win
-
-    //Match 4
-    newRating = EloRatingSnippet.calculateMatchRating(newRating, 1586.0, 1.0); //Win
-
-    //Match 5
-    newRating = EloRatingSnippet.calculateMatchRating(newRating, 1720.0, 0.0); //Loss
-
-    double expectedFinalRating = 1601.0; 
-    assertEquals(expectedFinalRating, initialRating, DELTA);
+    //Use a random result for testing purposes. A 100 point difference is
+    //typically 20~21 points difference in elo
+    assertEquals(1520.48, EloRatingSnippet.calculateMatchRating(1500, 1600, 1.0), DELTA);
   }
 }

--- a/src/test/java/math/EloRatingSnippetTest.java
+++ b/src/test/java/math/EloRatingSnippetTest.java
@@ -1,0 +1,80 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017-2023 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package math;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/*
+ * Tests for 30 Seconds of Java code library
+ *
+ */
+class EloRatingSnippetTest {
+
+   final double DELTA = 0.01; // Add tolerance for floating point calculations
+
+  /**
+   * Tests for {@link #calculateMatchRating(double, double, double)}.
+   */
+  @Test
+  void testSingleMatchRatings() {
+
+    
+
+    //No rating change for draw between players of equal strength
+    assertEquals(1500.0, EloRatingSnippet.calculateMatchRating(1500, 1500, 0.5), DELTA);
+
+    //For a win against a very very high leveled player, we should get max points
+    assertEquals(1532.0, EloRatingSnippet.calculateMatchRating(1500, 3000, 1.0), DELTA);
+
+    //For a loss against a very very low leveled player, we should lose max points
+    assertEquals(2968.0, EloRatingSnippet.calculateMatchRating(3000, 1500, 0.0), DELTA);
+  }
+
+  @Test
+  void testTournamentRatings() {
+
+      //Simulate a tournament, using data from wikipedia
+      double initialRating = 1613.0;
+      double expectedFinalRating = 1601.0; 
+      double newRating = EloRatingSnippet.calculateMatchRating(initialRating, 1609.0, 0); // Loss
+
+      //Match 2
+      newRating = EloRatingSnippet.calculateMatchRating(newRating, 1477.0, 0.5); //Draw
+
+      //Match 3
+      newRating = EloRatingSnippet.calculateMatchRating(newRating, 1388.0, 1.0); //Win
+
+      //Match 4
+      newRating = EloRatingSnippet.calculateMatchRating(newRating, 1586.0, 1.0); //Win
+
+      //Match 5
+      newRating = EloRatingSnippet.calculateMatchRating(newRating, 1720.0, 0.0); //Loss
+
+      assertEquals(expectedFinalRating, initialRating, DELTA);
+
+  }
+}


### PR DESCRIPTION
Fixes #34. Have couple of questions though:
- Provided a few constants to keep the function short, although they could be configurable. Should I create an overloaded function?
- Elo Ratings are often calculated across tournaments, with initial score as base (and not changing per match). Should we create another function for that? If yes, should I include it in this MR or make a separate one?  

@iluwatar thoughts?