### PR TITLE
Create simple thread using Java thread class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2016,6 +2016,23 @@ public class StringToDateSnippet {
 
 ### Thread Pool
 
+### Thread
+
+```java
+public class ThreadSnippet {
+
+  /**
+   * Creates and returns a new thread with the task assigned to it (task will be performed parallel to the main thread).
+   *
+   * @param task the task to be executed by this thread
+   * @return new thread with task assigned to it.
+   */
+  public static Thread createThread(Runnable task) {
+    return new Thread(task);
+  }
+}
+```
+
 ```java
 public class ThreadPool {
 

--- a/src/main/java/thread/ThreadSnippet.java
+++ b/src/main/java/thread/ThreadSnippet.java
@@ -30,7 +30,8 @@ package thread;
 public class ThreadSnippet {
 
   /**
-   * Creates and returns a new thread with the task assigned to it (task will be performed parallel to the main thread).
+   * Creates and returns a new thread with the task assigned to it
+   * (task will be performed parallel to the main thread).
    *
    * @param task the task to be executed by this thread
    * @return new thread with task assigned to it.

--- a/src/main/java/thread/ThreadSnippet.java
+++ b/src/main/java/thread/ThreadSnippet.java
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package thread;
+
+/**
+ * ThreadSnippet.
+ */
+public class ThreadSnippet {
+
+  /**
+   * Creates and returns a new thread with the task assigned to it (task will be performed parallel to the main thread).
+   *
+   * @param task the task to be executed by this thread
+   * @return new thread with task assigned to it.
+   */
+  public static Thread createThread(Runnable task) {
+    return new Thread(task);
+  }
+}

--- a/src/test/java/thread/ThreadSnippetTest.java
+++ b/src/test/java/thread/ThreadSnippetTest.java
@@ -24,11 +24,11 @@
 
 package thread;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * Tests for 30 Seconds of Java code library

--- a/src/test/java/thread/ThreadSnippetTest.java
+++ b/src/test/java/thread/ThreadSnippetTest.java
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package thread;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * Tests for 30 Seconds of Java code library
+ *
+ */
+class ThreadSnippetTest {
+
+  /**
+   * Tests for {@link ThreadSnippet#createThread(Runnable)}.
+   */
+  @Test
+  void createThread() throws InterruptedException {
+    AtomicInteger counter = new AtomicInteger(0);
+
+    Thread t = ThreadSnippet.createThread(() -> {
+      for (int i = 0; i < 1000000; i++) {
+        counter.getAndIncrement();
+      }
+    });
+
+    t.start();
+    t.join();
+
+    assertEquals(counter.get(), 1000000);
+  }
+}


### PR DESCRIPTION
The `createThread` method quickly creates new threads and assigns tasks to each for concurrent execution.