### PR TITLE
CI: Update GitHub Actions runner to ubuntu-latest

### DIFF
--- a/.github/workflows/gradle-ci.yml
+++ b/.github/workflows/gradle-ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-and-analyze:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gradle-pr-builder.yml
+++ b/.github/workflows/gradle-pr-builder.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-and-analyze:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
GitHub has deprecated the `ubuntu-20.04` runner for GitHub Actions as of April 15 ([announcement](https://github.com/actions/runner-images/issues/11101)). 

This PR updates the workflow configuration to use `ubuntu-latest`, which currently resolves to Ubuntu 22.04 LTS.
