### PR TITLE
Add SafeCastSnippet Utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -949,6 +949,26 @@ public class GetAllMethodsSnippet {
 }
 ```
 
+### Safe Cast
+
+```java
+public class SafeCastSnippet {
+
+  /**
+   * Safely casts an object to the specified type.
+   *
+   * @param obj object to cast
+   * @param clazz target type
+   * @param <T> target type parameter
+   * @return optional containing the cast object, or empty if the object is not
+   *     assignable to the target type
+   */
+  public static <T> Optional<T> safeCast(final Object obj, final Class<T> clazz) {
+    return clazz.isInstance(obj) ? Optional.of(clazz.cast(obj)) : Optional.empty();
+  }
+}
+```
+
 ### Get All Public Field Names
 
 ```java

--- a/src/main/java/cls/SafeCastSnippet.java
+++ b/src/main/java/cls/SafeCastSnippet.java
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package cls;
+
+import java.util.Optional;
+
+/**
+ * SafeCastSnippet.
+ */
+public class SafeCastSnippet {
+
+  /**
+   * Safely casts an object to the specified type.
+   *
+   * @param obj object to cast
+   * @param clazz target type
+   * @param <T> target type parameter
+   * @return optional containing the cast object, or empty if the object is not
+   *     assignable to the target type
+   */
+  public static <T> Optional<T> safeCast(final Object obj, final Class<T> clazz) {
+    return clazz.isInstance(obj) ? Optional.of(clazz.cast(obj)) : Optional.empty();
+  }
+}

--- a/src/test/java/cls/SafeCastSnippetTest.java
+++ b/src/test/java/cls/SafeCastSnippetTest.java
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package cls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/*
+ * Tests for 30 Seconds of Java code library
+ *
+ */
+class SafeCastSnippetTest {
+  /**
+   * Tests successful casts for {@link SafeCastSnippet#safeCast(Object, Class)}.
+   */
+  @Test
+  void testSafeCastSuccess() {
+    var result = SafeCastSnippet.safeCast("30 seconds", String.class);
+
+    assertTrue(result.isPresent());
+    assertEquals("30 seconds", result.get());
+  }
+
+  /**
+   * Tests failed casts for {@link SafeCastSnippet#safeCast(Object, Class)}.
+   */
+  @Test
+  void testSafeCastFailure() {
+    var result = SafeCastSnippet.safeCast("30 seconds", Integer.class);
+
+    assertTrue(result.isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #246 
Implements the `SafeCastSnippet` utility for safely casting objects using generics and returning the result as an `Optional`, avoiding `ClassCastException`.

## Changes

* Added `SafeCastSnippet` with a generic `safeCast(Object obj, Class<T> clazz)` method.
* Returns `Optional.empty()` when the object cannot be cast to the requested type.
* Added unit tests covering both successful and unsuccessful cast scenarios.
* Updated the README to include the new snippet.

## Testing

* Verified the project builds successfully with Java 21.
* Ran the test suite successfully using:

```bash
./gradlew clean test
```
