### PR TITLE
feat: add environment variable default snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1337,6 +1337,26 @@ public class ReadFileSnippet {
 }
 ```
 
+## System
+
+### Get Environment Variable Or Default
+
+```java
+public class GetEnvOrDefaultSnippet {
+
+  /**
+   * Read an environment variable or return a default value when it is missing.
+   *
+   * @param key environment variable name
+   * @param defaultValue value returned when the variable is missing
+   * @return environment variable value or default value
+   */
+  public static String getEnvOrDefault(String key, String defaultValue) {
+    return System.getenv().getOrDefault(key, defaultValue);
+  }
+}
+```
+
 ## Math
 
 ### Dice Throw

--- a/src/main/java/system/GetEnvOrDefaultSnippet.java
+++ b/src/main/java/system/GetEnvOrDefaultSnippet.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package system;
+
+/**
+ * GetEnvOrDefaultSnippet.
+ */
+public class GetEnvOrDefaultSnippet {
+
+  /**
+   * Read an environment variable or return a default value when it is missing.
+   *
+   * @param key environment variable name
+   * @param defaultValue value returned when the variable is missing
+   * @return environment variable value or default value
+   */
+  public static String getEnvOrDefault(String key, String defaultValue) {
+    return System.getenv().getOrDefault(key, defaultValue);
+  }
+}

--- a/src/test/java/system/GetEnvOrDefaultSnippetTest.java
+++ b/src/test/java/system/GetEnvOrDefaultSnippetTest.java
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class GetEnvOrDefaultSnippetTest {
+
+  /**
+   * Tests that an existing environment variable is returned.
+   */
+  @Test
+  void testPresentEnvironmentVariable() {
+    assertEquals(System.getenv("PATH"), GetEnvOrDefaultSnippet.getEnvOrDefault("PATH", "fallback"));
+  }
+
+  /**
+   * Tests that the default is returned for a missing environment variable.
+   */
+  @Test
+  void testMissingEnvironmentVariable() {
+    assertEquals("fallback", GetEnvOrDefaultSnippet.getEnvOrDefault(
+            "THIRTY_SECONDS_OF_JAVA_MISSING_ENV_VAR", "fallback"));
+  }
+}


### PR DESCRIPTION
## Summary
- add `GetEnvOrDefaultSnippet` for environment variables with a fallback value
- cover present and missing environment variable cases
- document the new System snippet in `README.md`

## Validation
- `./gradlew clean build --no-daemon` (Java 21)
- `./gradlew test --tests system.GetEnvOrDefaultSnippetTest --no-daemon` (Java 21)